### PR TITLE
install requirements as a post create command

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,5 +46,6 @@
                 }
             }
         }
-    }
+    },
+    "postCreateCommand": "pip install -r requirements.txt"
 }


### PR DESCRIPTION
This pull request includes a small change to the `.devcontainer/devcontainer.json` file. The change adds a `postCreateCommand` to install the required Python packages after the container is created.

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L49-R50): Added `postCreateCommand` to install dependencies from `requirements.txt` after container creation.