### PR TITLE
remove hardcoded database variables

### DIFF
--- a/.devcontainer/.env.sample
+++ b/.devcontainer/.env.sample
@@ -5,3 +5,9 @@ OAUTH_42_CLIENT_SECRET="s-s4t2ud-xxxxx"
 REDIS_PASSWORD="super_secure_password"
 REDIS_PORT=6379
 REDIS_DATABASES=16
+
+# Postgres
+POSTGRES_USER="postgres"
+POSTGRES_PASSWORD="super_secure_password"
+POSTGRES_DB="postgres"
+POSTGRES_PORT=5432

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -18,10 +18,8 @@ services:
       - postgres-data:/var/lib/postgresql/data
     networks:
       - barely_a_network
-    environment:
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_USER: postgres
-      POSTGRES_DB: postgres
+    env_file:
+      - .env
 
   redis:
     image: redis:latest

--- a/transcendence/transcendence/settings.py
+++ b/transcendence/transcendence/settings.py
@@ -137,14 +137,19 @@ CHANNEL_LAYERS = {
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
+DB_USER = os.getenv("POSTGRES_USER")
+DB_PASSWORD = os.getenv("POSTGRES_PASSWORD")
+DB_NAME = os.getenv("POSTGRES_DB")
+DB_PORT = os.getenv("POSTGRES_PORT")
+
 DATABASES = {
     'default': {
         'ENGINE': 'django_prometheus.db.backends.postgresql',
-        'NAME': 'postgres',
-        'USER': 'postgres',
-        'PASSWORD': 'postgres',
+        'NAME': DB_NAME,
+        'USER': DB_USER,
+        'PASSWORD': DB_PASSWORD,
         'HOST': 'db',
-        'PORT': '5432',
+        'PORT': DB_PORT,
     }
 }
 


### PR DESCRIPTION
This pull request introduces several changes to improve the configuration and management of environment variables for the Postgres database. The changes include the addition of environment variables in a sample environment file, updating the Docker Compose configuration to use these variables, and modifying the Django settings to read from the environment variables.

Changes to environment variable management:

* [`.devcontainer/.env.sample`](diffhunk://#diff-e43af9f217e778e159273c8b2c475150122ad0ccf0525cb2bce1edd237ca5f03R8-R13): Added environment variables for Postgres configuration, including `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, and `POSTGRES_PORT`.

* [`.devcontainer/docker-compose.yml`](diffhunk://#diff-67a4805fdcc6145d7b3ada2a6099a9b2e91c9d0fd108c22f95d2f01d219793d1L21-R22): Updated the Postgres service configuration to use environment variables from the `.env` file instead of hardcoding them.

Changes to Django settings:

* [`transcendence/transcendence/settings.py`](diffhunk://#diff-39db90c92626096e70d82a4acc358b80a0f0b03fd5a0a0e60dcf58cdf8e9b6b2R140-R152): Modified the database configuration to read `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, and `POSTGRES_PORT` from environment variables.