### PR TITLE
change bootstrap so footer is allways botom

### DIFF
--- a/transcendence/templates/base.html
+++ b/transcendence/templates/base.html
@@ -17,11 +17,11 @@
         <script src="{% static 'js/htmx.min.js' %}" defer></script>
         {% block extra_head %}{% endblock %}
     </head>
-    <body>
+    <body class="d-flex flex-column min-vh-100">
         <!-- Cargar el Header desde un partial -->
         <div id="header-container">{% include "partials/header.html" %}</div>
         <!-- Contenido dinámico -->
-        <main id="content" class="container my-4">
+        <main id="content" class="container my-4 flex-fill">
             {% block content %}
             {% endblock content %}
         </main>

--- a/transcendence/templates/partials/footer.html
+++ b/transcendence/templates/partials/footer.html
@@ -1,3 +1,3 @@
-<footer class="bg-dark text-white text-center py-3">
+<footer class="bg-dark text-white text-center py-3 mt-auto">
     <p class="mb-0">footer</p>
 </footer>


### PR DESCRIPTION
This pull request includes changes to improve the layout and styling of the webpage by ensuring the footer stays at the bottom of the page, even with minimal content. The most important changes include modifying the `base.html` and `footer.html` templates.

Layout and styling improvements:

* [`transcendence/templates/base.html`](diffhunk://#diff-a0e91b529918c42d2b4124267ab36da05775fdd244fa469a2d4aebe3d285754bL20-R24): Added classes `d-flex flex-column min-vh-100` to the `body` tag and `flex-fill` to the `main` tag to ensure the footer stays at the bottom of the page.
* [`transcendence/templates/partials/footer.html`](diffhunk://#diff-96e4258be2dcb16fefdc8109c92ca91084620704c66bf276eb1cf6383c058fd6L1-R1): Added `mt-auto` class to the `footer` tag to ensure it is pushed to the bottom of the page.